### PR TITLE
Introduce contextmanager for ConnectionPool

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ connection_pool = ConnectionPool()
 # if the given servers are ok, return true, else return false
 ok = connection_pool.init([('127.0.0.1', 3699)], config)
 
+# option 1 control the connection release yourself
 # get session from the pool
 session = connection_pool.get_session('root', 'nebula')
 
@@ -92,6 +93,12 @@ print(result)
 
 # release session
 session.release()
+
+# option 2 with session_context, session will be released automatically
+with connection_pool.session_context('root', 'nebula') as session:
+    session.execute('USE nba')
+    result = session.execute('SHOW TAGS')
+    print(result)
 
 # close the pool
 connection_pool.close()

--- a/nebula2/gclient/net/__init__.py
+++ b/nebula2/gclient/net/__init__.py
@@ -7,6 +7,7 @@
 # attached with Common Clause Condition 1.0, found in the LICENSES directory.
 
 
+import contextlib
 import threading
 import logging
 import time
@@ -178,6 +179,30 @@ class ConnectionPool(object):
             return Session(connection, session_id, self, retry_connect)
         except Exception:
             raise
+
+    @contextlib.contextmanager
+    def session_context(self, *args, **kwargs):
+        """
+        session_context is to be used with a contextlib.contextmanager.
+        It returns a connection session from the pool, with same params
+        as the method get_session().
+
+        When session_context is exited, the connection will be released.
+
+        :param user_name:
+        :param password:
+        :param retry_connect: if auto retry connect
+        :return: contextlib._GeneratorContextManager
+        """
+        session = None
+        try:
+            session = self.get_session(*args, **kwargs)
+            yield session
+        except Exception:
+            raise
+        finally:
+            if session:
+                session.release()
 
     def get_connection(self):
         """

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -48,7 +48,7 @@ class TestSession(TestCase):
             session = self.pool.get_session('root', 'nebula')
             for i in range(0, 5):
                 if i == 3:
-                    os.system('docker stop nebula-docker-compose_graphd_1')
+                    os.system('docker stop nebula-docker-compose_graphd0_1')
                     os.system('docker stop nebula-docker-compose_graphd1_1')
                     time.sleep(3)
                 resp = session.execute('SHOW SPACES')
@@ -63,6 +63,12 @@ class TestSession(TestCase):
         except Exception as e:
             assert False, e
         finally:
-            os.system('docker start nebula-docker-compose_graphd_1')
+            os.system('docker start nebula-docker-compose_graphd0_1')
             os.system('docker start nebula-docker-compose_graphd1_1')
             time.sleep(5)
+
+    def test_3_session_context(self):
+        in_used_connects = self.pool.in_used_connects()
+        with self.pool.session_context('root', 'nebula') as session:
+            assert self.pool.in_used_connects() == in_used_connects + 1
+        assert self.pool.in_used_connects() == in_used_connects


### PR DESCRIPTION
This commit introduced a new method ConnectionPool.session_context,
which takes exactly the same arguments as ConnectionPool.get_session.
It's just a context manager for handling connection sessions.

Issue:(#84)

Signed-off-by: Wey Gu <weyl.gu@gmail.com>