### PR TITLE
update GraphStorageClient.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ meta_cache = MetaCache([('172.28.1.1', 9559),
                         ('172.28.1.3', 9559)],
                        50000)
 
-# option 1 metad usually discover the storage addresses automatically
+# option 1 metad usually discover the storage address automatically
 graph_storage_client = GraphStorageClient(meta_cache)
 
-# option 2 manually specify the storage addresses
+# option 2 manually specify the storage address
 storage_addrs = [HostAddr(host='172.28.1.4',port=9779),
                  HostAddr(host='172.28.1.5',port=9779),
                  HostAddr(host='172.28.1.6',port=9779)]

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ graph_storage_client = GraphStorageClient(meta_cache)
 storage_addrs = [HostAddr(host='172.28.1.4', port=9779),
                  HostAddr(host='172.28.1.5', port=9779),
                  HostAddr(host='172.28.1.6', port=9779)]
-graph_storage_client = GraphStorageClient(meta_cache,storage_addrs)
+graph_storage_client = GraphStorageClient(meta_cache, storage_addrs)
 
 resp = graph_storage_client.scan_vertex(
         space_name='ScanSpace',

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ connection_pool.close()
 You should make sure the scan client can connect to the address of storage which see from `SHOW HOSTS` 
 
 ```python
-from nebula2.mclient import MetaCache
+from nebula2.mclient import MetaCache,HostAddr
 from nebula2.sclient.GraphStorageClient import GraphStorageClient
 
 # the metad servers's address
@@ -119,7 +119,11 @@ meta_cache = MetaCache([('172.28.1.1', 9559),
                         ('172.28.1.2', 9559),
                         ('172.28.1.3', 9559)],
                        50000)
-graph_storage_client = GraphStorageClient(meta_cache)
+storage_addrs = [HostAddr(host='172.28.1.4',port=9779),
+                 HostAddr(host='172.28.1.5',port=9779),
+                 HostAddr(host='172.28.1.6',port=9779),]
+
+graph_storage_client = GraphStorageClient(meta_cache,storage_addrs)
 
 resp = graph_storage_client.scan_vertex(
         space_name='ScanSpace',

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ with connection_pool.session_context('root', 'nebula') as session:
 connection_pool.close()
 ```
 
-## Quick example to use storage-cleint to scan vertex and edge
+## Quick example to use storage-client to scan vertex and edge
 
 You should make sure the scan client can connect to the address of storage which see from `SHOW HOSTS` 
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ connection_pool.close()
 You should make sure the scan client can connect to the address of storage which see from `SHOW HOSTS` 
 
 ```python
-from nebula2.mclient import MetaCache,HostAddr
+from nebula2.mclient import MetaCache, HostAddr
 from nebula2.sclient.GraphStorageClient import GraphStorageClient
 
 # the metad servers's address
@@ -124,9 +124,9 @@ meta_cache = MetaCache([('172.28.1.1', 9559),
 graph_storage_client = GraphStorageClient(meta_cache)
 
 # option 2 manually specify the storage address
-storage_addrs = [HostAddr(host='172.28.1.4',port=9779),
-                 HostAddr(host='172.28.1.5',port=9779),
-                 HostAddr(host='172.28.1.6',port=9779)]
+storage_addrs = [HostAddr(host='172.28.1.4', port=9779),
+                 HostAddr(host='172.28.1.5', port=9779),
+                 HostAddr(host='172.28.1.6', port=9779)]
 graph_storage_client = GraphStorageClient(meta_cache,storage_addrs)
 
 resp = graph_storage_client.scan_vertex(

--- a/README.md
+++ b/README.md
@@ -119,10 +119,14 @@ meta_cache = MetaCache([('172.28.1.1', 9559),
                         ('172.28.1.2', 9559),
                         ('172.28.1.3', 9559)],
                        50000)
+
+# option 1 metad usually discover the storage addresses automatically
+graph_storage_client = GraphStorageClient(meta_cache)
+
+# option 2 manually specify the storage addresses
 storage_addrs = [HostAddr(host='172.28.1.4',port=9779),
                  HostAddr(host='172.28.1.5',port=9779),
-                 HostAddr(host='172.28.1.6',port=9779),]
-
+                 HostAddr(host='172.28.1.6',port=9779)]
 graph_storage_client = GraphStorageClient(meta_cache,storage_addrs)
 
 resp = graph_storage_client.scan_vertex(

--- a/nebula2/sclient/GraphStorageClient.py
+++ b/nebula2/sclient/GraphStorageClient.py
@@ -34,11 +34,13 @@ class GraphStorageClient(object):
     DEFAULT_END_TIME = sys.maxsize
     DEFAULT_LIMIT = 1000
 
-    def __init__(self, meta_cache, time_out=60000):
+    def __init__(self, meta_cache,storage_addrs =None, time_out=60000):
         self._meta_cache = meta_cache
+        self.storage_addrs = storage_addrs
         self._time_out = time_out
         self._connections = []
         self._create_connection()
+        
 
     def get_conns(self):
         """get all connections which connect to storaged, the ScanResult use it
@@ -67,11 +69,12 @@ class GraphStorageClient(object):
 
         :return: GraphStorageConnection
         """
-        storage_addrs = self._meta_cache.get_all_storage_addrs()
-        if len(storage_addrs) == 0:
+        if self.storage_addrs is None:
+            self.storage_addrs = self._meta_cache.get_all_storage_addrs()
+        if len(self.storage_addrs) == 0:
             raise RuntimeError('Get storage address from meta cache is empty')
         try:
-            for addr in storage_addrs:
+            for addr in self.storage_addrs:
                 conn = GraphStorageConnection(addr, self._time_out, self._meta_cache)
                 conn.open()
                 self._connections.append(conn)

--- a/nebula2/sclient/GraphStorageClient.py
+++ b/nebula2/sclient/GraphStorageClient.py
@@ -34,13 +34,12 @@ class GraphStorageClient(object):
     DEFAULT_END_TIME = sys.maxsize
     DEFAULT_LIMIT = 1000
 
-    def __init__(self, meta_cache,storage_addrs =None, time_out=60000):
+    def __init__(self, meta_cache, storage_addrs=None, time_out=60000):
         self._meta_cache = meta_cache
         self.storage_addrs = storage_addrs
         self._time_out = time_out
         self._connections = []
         self._create_connection()
-        
 
     def get_conns(self):
         """get all connections which connect to storaged, the ScanResult use it

--- a/nebula2/sclient/GraphStorageClient.py
+++ b/nebula2/sclient/GraphStorageClient.py
@@ -36,7 +36,7 @@ class GraphStorageClient(object):
 
     def __init__(self, meta_cache, storage_addrs=None, time_out=60000):
         self._meta_cache = meta_cache
-        self.storage_addrs = storage_addrs
+        self._storage_addrs = storage_addrs
         self._time_out = time_out
         self._connections = []
         self._create_connection()
@@ -68,12 +68,12 @@ class GraphStorageClient(object):
 
         :return: GraphStorageConnection
         """
-        if self.storage_addrs is None:
-            self.storage_addrs = self._meta_cache.get_all_storage_addrs()
-        if len(self.storage_addrs) == 0:
+        if self._storage_addrs is None:
+            self._storage_addrs = self._meta_cache.get_all_storage_addrs()
+        if len(self._storage_addrs) == 0:
             raise RuntimeError('Get storage address from meta cache is empty')
         try:
-            for addr in self.storage_addrs:
+            for addr in self._storage_addrs:
                 conn = GraphStorageConnection(addr, self._time_out, self._meta_cache)
                 conn.open()
                 self._connections.append(conn)


### PR DESCRIPTION
1. 更新 GraphStorageClient.py 中的类 GraphStorageClient。
2. 为此 修改 readme.md 样例。

原因： 使用 nebula-docker-compose 拉起环境后，宿主机上安装 nebula-python 在运行第二个样例时报错：
InValidHostname: storaged0，宿主机无法识别 storaged0
![](https://gitee.com/kevin777/wechat_pictures/raw/master/2021-9-13/1631546978076-image.png)

#### 解决方案
通过手动配置 storage_addrs，并将其作为参数传入其中，来解决。
使用if条件判断，提供更多自由度

![](https://gitee.com/kevin777/wechat_pictures/raw/master/2021-9-13/1631547106791-image.png)

