### PR TITLE
Improve the package description and set long_description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,20 +7,27 @@
 
 
 from setuptools import setup, find_packages
+from pathlib import Path
+
+base_dir = Path(__file__).parent
+long_description = (base_dir / 'README.md').read_text()
+
 
 setup(
     name='nebula2-python',
     version='2.5.0',
-    license="Apache 2.0 + Common Clause 1.0",
+    license='Apache 2.0 + Common Clause 1.0',
     author='vesoft-inc',
     author_email='info@vesoft.com',
-    long_description='Python client for Nebula Graph V2.0',
+    description='Python client for Nebula Graph V2.0',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     url='https://github.com/vesoft-inc/nebula-python',
     install_requires=['httplib2',
                       'future',
                       'six',
                       'pytz'],
     packages=find_packages(),
-    platforms=["3.5, 3.7"],
+    platforms=['3.5, 3.7'],
     package_dir={'nebula2': 'nebula2'},
 )


### PR DESCRIPTION
The current value of `long_description` should point to `description`. This PR also read the content from README as `long_description`.

(Check the current value on PyPI page: https://pypi.org/project/nebula2-python/)