### PR TITLE
fix scan vertex index for prop value

### DIFF
--- a/nebula3/sclient/BaseResult.py
+++ b/nebula3/sclient/BaseResult.py
@@ -75,7 +75,7 @@ class VertexData(object):
         tag.props = {}
         index = self.PROP_START_INDEX
         while index < len(self._col_names):
-            tag.props[self._col_names[index]] = self._row.values[index]
+            tag.props[self._col_names[index]] = self._row.values[index + 1]
             index = index + 1
         vertex.tags.append(tag)
 


### PR DESCRIPTION
close #218

From:

https://github.com/vesoft-inc/nebula-python/blob/800f0f96babac87e7aa004534cc4da2b63ed5922/nebula3/sclient/BaseResult.py#L78

we could see the index was mismatched:

```python
(Pdb) self._row.values
[Value(sVal=b'player112'), Value(sVal=b'player112'), Value(sVal=b'Jonathon Simmons'), Value(iVal=29)]
(Pdb) self._col_names
[b'_vid', b'name', b'age']
```