### PR TITLE
feature/auto-cast

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ def result_to_df(result: ResultSet) -> pd.DataFrame:
         col_name = columns[col_num]
         col_list = result.column_values(col_name)
         d[col_name] = [x.cast() for x in col_list]
-    return pd.DataFrame.from_dict(d)
+    return pd.DataFrame.from_dict(d, columns=columns)
 
 # define a config
 config = Config()

--- a/README.md
+++ b/README.md
@@ -99,6 +99,49 @@ with connection_pool.session_context('root', 'nebula') as session:
 connection_pool.close()
 ```
 
+## Quick example to fetch result to dataframe
+
+```python
+from nebula3.gclient.net import ConnectionPool
+from nebula3.Config import Config
+import pandas as pd
+from typing import Dict
+from nebula3.data.ResultSet import ResultSet
+
+def result_to_df(result: ResultSet) -> pd.DataFrame:
+    """
+    build list for each column, and transform to dataframe
+    """
+    assert result.is_succeeded()
+    columns = result.keys()
+    d: Dict[str, list] = {}
+    for col_num in range(result.col_size()):
+        col_name = columns[col_num]
+        col_list = result.column_values(col_name)
+        d[col_name] = [x.cast() for x in col_list]
+    return pd.DataFrame.from_dict(d)
+
+# define a config
+config = Config()
+
+# init connection pool
+connection_pool = ConnectionPool()
+
+# if the given servers are ok, return true, else return false
+ok = connection_pool.init([('127.0.0.1', 9669)], config)
+
+# option 2 with session_context, session will be released automatically
+with connection_pool.session_context('root', 'nebula') as session:
+    session.execute('USE <your graph space>')
+    result = session.execute('<your query>')
+    df = result_to_df(result)
+    print(df)
+
+# close the pool
+connection_pool.close()
+
+```
+
 ## Quick example to use storage-client to scan vertex and edge
 
 You should make sure the scan client can connect to the address of storage which see from `SHOW HOSTS` 

--- a/example/FormatResp.py
+++ b/example/FormatResp.py
@@ -58,7 +58,7 @@ cast_as = {
 def customized_cast_with_dict(val: ValueWrapper):
     _type = val._value.getType()
     method = cast_as.get(_type)
-    if method != None:
+    if method is not None:
         return getattr(val, method, lambda *args, **kwargs: None)()
     raise KeyError("No such key: {}".format(_type))
 

--- a/example/FormatResp.py
+++ b/example/FormatResp.py
@@ -28,7 +28,7 @@ def result_to_df(result: ResultSet) -> pd.DataFrame:
         col_name = columns[col_num]
         col_list = result.column_values(col_name)
         d[col_name] = [x.cast() for x in col_list]
-    return pd.DataFrame.from_dict(d)
+    return pd.DataFrame.from_dict(d, columns=columns)
 
 
 ################################

--- a/example/FormatResp.py
+++ b/example/FormatResp.py
@@ -57,7 +57,10 @@ cast_as = {
 
 def customized_cast_with_dict(val: ValueWrapper):
     _type = val._value.getType()
-    return getattr(_type, cast_as(_type))()
+    method = cast_as.get(_type)
+    if method != None:
+        return getattr(val, method, lambda *args, **kwargs: None)()
+    raise KeyError("No such key: {}".format(_type))
 
 
 def print_resp(resp: ResultSet):

--- a/nebula3/data/DataObject.py
+++ b/nebula3/data/DataObject.py
@@ -686,22 +686,7 @@ class ValueWrapper(object):
         : return: Any type (e.g. int, float, List[Dict[str, int]], Set[List[float]])
         """
         _type = self._value.getType()
-        if _type in {
-            Value.NVAL,
-            Value.__EMPTY__,
-            Value.BVAL,
-            Value.IVAL,
-            Value.FVAL,
-            Value.SVAL,
-            Value.TVAL,
-            Value.DVAL,
-            Value.DTVAL,
-            Value.VVAL,
-            Value.EVAL,
-            Value.PVAL,
-            Value.GGVAL,
-            Value.DUVAL,
-        }:
+        if _type in __AS_MAP__:
             # Considering the most efficient way, we should call `cast` in every iterable method over their items,
             # such as `as_list`, `as_set`, and `as_map`. However, the returned type will change and cause incompatibility.
             # So I put the common types set (time complexity O(1)) at first, and call their method via dict ( O(1) )

--- a/tests/test_data_type.py
+++ b/tests/test_data_type.py
@@ -318,6 +318,64 @@ class TesValueWrapper(TestBaseCase):
         expect_result["b"] = ValueWrapper(ttypes.Value(sVal=b"car"))
         assert map_val == expect_result
 
+    def test_cast(self):
+        value = ttypes.Value()
+
+        bool_val = ttypes.Value()
+        bool_val.set_bVal(False)
+
+        int_val = ttypes.Value()
+        int_val.set_iVal(100)
+
+        float_val = ttypes.Value()
+        float_val.set_fVal(10.10)
+
+        str_val1 = ttypes.Value()
+        str_val1.set_sVal(b"word")
+
+        str_val2 = ttypes.Value()
+        str_val2.set_sVal(b"car")
+
+        set_val = ttypes.Value()
+        tmp_set_val = NSet()
+        tmp_set_val.values = set()
+        tmp_set_val.values.add(str_val1)
+        tmp_set_val.values.add(str_val2)
+        set_val.set_uVal(tmp_set_val)
+
+        map_val = ttypes.Value()
+        tmp_map_val = NMap()
+        tmp_map_val.kvs = {b"a": str_val1, b"b": str_val2}
+        map_val.set_mVal(tmp_map_val)
+
+        tmp_list_val = NList()
+        tmp_list_val.values = [
+            bool_val,
+            int_val,
+            float_val,
+            str_val1,
+            str_val2,
+            set_val,
+            map_val,
+        ]
+        value.set_lVal(tmp_list_val)
+
+        value = ValueWrapper(value)
+
+        list_val = value.cast()
+        assert isinstance(list_val, list)
+
+        expect_result = [
+            False,
+            100,
+            10.10,
+            "word",
+            "car",
+            {"word", "car"},
+            {"a": "word", "b": "car"},
+        ]
+        assert list_val == expect_result
+
     def test_as_time(self):
         time = Time()
         time.hour = 10


### PR DESCRIPTION
1. Add method `cast` in `ValueWrapper` for automatically casting to python basic type
2. Add and pass unit test for `cast` method
3. Add examples and README

> For the most efficient way, we should call `cast` in every iterable method over their items,
> (e.g. calling `cast` in `as_list()` ). However, the returned type will change and cause incompatible.
> So I try to preserve the if-else statement in a better way, and recursively call `cast` when `_value` is iterable