### PR TITLE
Add session pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ with connection_pool.session_context('root', 'nebula') as session:
 connection_pool.close()
 ```
 
+## Example of using session pool
+```
+There are some limitations while using the session pool:
+
+1. There MUST be an existing space in the DB before initializing the session pool.
+2. Each session pool is corresponding to a single USER and a single Space. This is to ensure that the user's access control is consistent. i.g. The same user may have different access privileges in different spaces. If you need to run queries in different spaces, you may have multiple session pools.
+3. Every time when sessinPool.execute() is called, the session will execute the query in the space set in the session pool config.
+4. Commands that alter passwords or drop users should NOT be executed via session pool.
+```
+see /example/SessinPoolExample.py
 ## Quick example to fetch result to dataframe
 
 ```python

--- a/example/SessinPoolExample.py
+++ b/example/SessinPoolExample.py
@@ -17,7 +17,7 @@ from FormatResp import print_resp
 
 if __name__ == '__main__':
     ip = '127.0.0.1'
-    port = 29562
+    port = 3699
 
     try:
         config = SessionPoolConfig()
@@ -64,15 +64,16 @@ if __name__ == '__main__':
         assert resp.is_succeeded(), resp.error_msg()
         print_resp(resp)
 
-        # # drop space
-        # conn.execute(
-        #     auth_result._session_id,
-        #     'DROP SPACE session_pool_test',
-        # )
+        # drop space
+        conn.execute(
+            auth_result._session_id,
+            'DROP SPACE session_pool_test',
+        )
 
         print("Example finished")
 
     except Exception as x:
         import traceback
+
         print(traceback.format_exc())
         exit(1)

--- a/example/SessinPoolExample.py
+++ b/example/SessinPoolExample.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+# --coding:utf-8--
+
+# Copyright (c) 2022 vesoft inc. All rights reserved.
+#
+# This source code is licensed under Apache 2.0 License.
+
+
+import time
+from nebula3.common.ttypes import ErrorCode
+
+from nebula3.gclient.net import Connection
+from nebula3.gclient.net.SessionPool import SessionPool
+from nebula3.Config import SessionPoolConfig
+from nebula3.common import *
+from FormatResp import print_resp
+
+if __name__ == '__main__':
+    ip = '127.0.0.1'
+    port = 29562
+
+    try:
+        config = SessionPoolConfig()
+
+        # prepare space
+        conn = Connection()
+        conn.open(ip, port, 1000)
+        auth_result = conn.authenticate('root', 'nebula')
+        assert auth_result.get_session_id() != 0
+        resp = conn.execute(
+            auth_result._session_id,
+            'CREATE SPACE IF NOT EXISTS session_pool_test(vid_type=FIXED_STRING(30))',
+        )
+        assert resp.error_code == ErrorCode.SUCCEEDED
+        # insert data need to sleep after create schema
+        time.sleep(10)
+
+        # init session pool
+        session_pool = SessionPool('root', 'nebula', 'session_pool_test', [(ip, port)])
+        assert session_pool.init(config)
+
+        # add schema
+        resp = session_pool.execute(
+            'CREATE TAG IF NOT EXISTS person(name string, age int);'
+            'CREATE EDGE like (likeness double);'
+        )
+        # insert vertex
+        resp = session_pool.execute(
+            'INSERT VERTEX person(name, age) VALUES "Bob":("Bob", 10), "Lily":("Lily", 9)'
+        )
+        assert resp.is_succeeded(), resp.error_msg()
+
+        # insert edges
+        resp = session_pool.execute(
+            'INSERT EDGE like(likeness) VALUES "Bob"->"Lily":(80.0);'
+        )
+        assert resp.is_succeeded(), resp.error_msg()
+
+        resp = session_pool.execute('FETCH PROP ON person "Bob" YIELD vertex as node')
+        assert resp.is_succeeded(), resp.error_msg()
+        print_resp(resp)
+
+        resp = session_pool.execute('FETCH PROP ON like "Bob"->"Lily" YIELD edge as e')
+        assert resp.is_succeeded(), resp.error_msg()
+        print_resp(resp)
+
+        # # drop space
+        # conn.execute(
+        #     auth_result._session_id,
+        #     'DROP SPACE session_pool_test',
+        # )
+
+        print("Example finished")
+
+    except Exception as x:
+        import traceback
+        print(traceback.format_exc())
+        exit(1)

--- a/nebula3/Config.py
+++ b/nebula3/Config.py
@@ -83,6 +83,7 @@ class SessionPoolConfig(object):
     @ min_size(int): the min size of the session
     @ interval_check(int): the interval to check the idle time of the session
     """
+
     timeout = 0
     idle_time = 0
     max_size = 30

--- a/nebula3/Config.py
+++ b/nebula3/Config.py
@@ -73,3 +73,25 @@ class SSL_config(object):
     keyfile = None
     certfile = None
     allow_weak_ssl_versions = False
+
+
+class SessionConfig(object):
+    """The configs for the session pool
+    @ username(str): the username of the user
+    @ password(str): the password of the user
+    @ space_name(str): the space name to connect
+    @ timeout(int): the timeout of the session
+    @ idle_time(int): the idle time of the session
+    @ max_size(int): the max size of the session
+    @ min_size(int): the min size of the session
+    @ interval_check(int): the interval to check the idle time of the session
+    """
+
+    username = ""
+    password = ""
+    space_name = ""
+    timeout = 0
+    idle_time = 0
+    max_size = 30
+    min_size = 0
+    interval_check = -1

--- a/nebula3/Config.py
+++ b/nebula3/Config.py
@@ -75,23 +75,16 @@ class SSL_config(object):
     allow_weak_ssl_versions = False
 
 
-class SessionConfig(object):
+class SessionPoolConfig(object):
     """The configs for the session pool
-    @ username(str): the username of the user
-    @ password(str): the password of the user
-    @ space_name(str): the space name to connect
     @ timeout(int): the timeout of the session
     @ idle_time(int): the idle time of the session
     @ max_size(int): the max size of the session
     @ min_size(int): the min size of the session
     @ interval_check(int): the interval to check the idle time of the session
     """
-
-    username = ""
-    password = ""
-    space_name = ""
     timeout = 0
     idle_time = 0
     max_size = 30
-    min_size = 0
+    min_size = 1
     interval_check = -1

--- a/nebula3/Exception.py
+++ b/nebula3/Exception.py
@@ -61,9 +61,9 @@ class NotValidConnectionException(Exception):
 
 
 class NoValidSessionException(Exception):
-    def __init__(self):
-        Exception.__init__(self)
-        self.message = 'No extra connection'
+    def __init__(self, message):
+        Exception.__init__(self, message)
+        self.message = 'Failed to get a valid session from the pool: {}'.format(message)
 
 
 class InValidHostname(Exception):

--- a/nebula3/Exception.py
+++ b/nebula3/Exception.py
@@ -60,6 +60,12 @@ class NotValidConnectionException(Exception):
         self.message = 'No extra connection'
 
 
+class NoValidSessionException(Exception):
+    def __init__(self):
+        Exception.__init__(self)
+        self.message = 'No extra connection'
+
+
 class InValidHostname(Exception):
     def __init__(self, message):
         Exception.__init__(self, message)

--- a/nebula3/gclient/net/Session.py
+++ b/nebula3/gclient/net/Session.py
@@ -23,8 +23,11 @@ class Session(object):
         self._timezone_offset = auth_result.get_timezone_offset()
         self._connection = connection
         self._timezone = 0
+        # connection the where the session was created, if session pool was used
         self._pool = pool
         self._retry_connect = retry_connect
+        # the time stamp when the session was added to the idle list of the session pool
+        self._idle_time_start = 0
 
     def execute_parameter(self, stmt, params):
         """execute statement

--- a/nebula3/gclient/net/Session.py
+++ b/nebula3/gclient/net/Session.py
@@ -234,13 +234,22 @@ class Session(object):
         self._connection = None
 
     def ping(self):
-        """check the connection is ok
+        """ping at connection level check the connection is valid
 
         :return: True or False
         """
         if self._connection is None:
             return False
         return self._connection.ping()
+
+    def ping_session(self):
+        """ping at session level, check whether the session is usable"""
+        resp = self.execute(r'RETURN "SESSION PING"')
+        if resp.is_succeeded():
+            return True
+        else:
+            logger.error('failed to ping the session: error code:{}, error message:{}'.format(resp.error_code, resp.error_msg))
+            return False
 
     def _reconnect(self):
         try:

--- a/nebula3/gclient/net/SessionPool.py
+++ b/nebula3/gclient/net/SessionPool.py
@@ -11,7 +11,7 @@ import socket
 from threading import RLock, Timer
 import time
 
-from nebula3.Exception import NoValidSessionException, InValidHostname
+from nebula3.Exception import AuthFailedException, NoValidSessionException, InValidHostname
 
 from nebula3.gclient.net.Session import Session
 from nebula3.gclient.net.Connection import Connection
@@ -352,6 +352,10 @@ class SessionPool(object):
                             )
                         )
                     return session
+                except AuthFailedException as e:
+                    # if auth failed, close the pool
+                    logger.error('Authentication failed, close the pool {}'.format(e))
+                    self.close()
                 except Exception:
                     raise
         else:

--- a/nebula3/gclient/net/SessionPool.py
+++ b/nebula3/gclient/net/SessionPool.py
@@ -1,0 +1,256 @@
+# --coding:utf-8--
+#
+# Copyright (c) 2022 vesoft inc. All rights reserved.
+#
+# This source code is licensed under Apache 2.0 License.
+
+
+import socket
+
+from threading import RLock, Timer
+
+from nebula3.Exception import NotValidConnectionException, InValidHostname
+
+from nebula3.gclient.net.Session import Session
+from nebula3.gclient.net.Connection import Connection
+from nebula3.logger import logger
+from nebula3.Config import SessionConfig
+
+
+class SessionPool(object):
+    S_OK = 0
+    S_BAD = 1
+
+    def __init__(self):
+        # all addresses of servers
+        self._addresses = list()
+
+        # server's status
+        self._addresses_status = dict()
+
+        # sessions that are currently in use
+        self._active_sessions = list()
+        # sessions that are currently available
+        self._idle_sessions = list()
+
+        self._configs = SessionConfig()
+        self._ssl_configs = None
+        self._lock = RLock()
+        self._pos = -1
+        self._close = False
+
+    def __del__(self):
+        self.close()
+
+    def init(self, addresses, configs):
+        """init the session pool
+
+        :param configs: the config of the pool
+        :return: if all addresses are valid, return True else return False.
+        """
+        # check configs
+        try:
+            self._check_configs()
+        except Exception as e:
+            logger.error('Invalid configs: {}'.format(e))
+            return False
+
+        if self._close:
+            logger.error('The pool has init or closed.')
+            raise RuntimeError('The pool has init or closed.')
+        self._configs = configs
+
+        for address in addresses:
+            if address not in self._addresses:
+                try:
+                    ip = socket.gethostbyname(address[0])
+                except Exception:
+                    raise InValidHostname(str(address[0]))
+                ip_port = (ip, address[1])
+                self._addresses.append(ip_port)
+                self._addresses_status[ip_port] = self.S_BAD
+
+        # ping all servers
+        self.update_servers_status()
+
+        # check services status in the background
+        self._period_detect()
+
+        ok_num = self.get_ok_servers_num()
+        if ok_num < len(self._addresses):
+            raise RuntimeError(
+                'The services status exception: {}'.format(self._get_services_status())
+            )
+
+        # iterate all addresses and create sessions to fullfil the min_size
+        for i in range(self._configs.min_size):
+            session = self._new_session()
+            if session is None:
+                raise RuntimeError('Get session failed')
+            self._idle_sessions.append(session)
+
+        return True
+
+    def _new_session(self):
+        """get a valid session with the username and password in the pool.
+            also, the session is bound to the space specified in the configs.
+
+        :return: Session
+        """
+        self._pos = (self._pos + 1) % len(self._addresses)
+        addr = self._addresses[self._pos]
+        if self._addresses_status[addr] == self.S_OK:
+            if self._ssl_configs is None:
+                connection = Connection()
+                try:
+                    connection.open(addr[0], addr[1], self._configs.timeout)
+                    auth_result = connection.authenticate(
+                        self._configs.username, self._configs.password
+                    )
+                    session = Session(connection, auth_result, self, False)
+                    resp = session.execute('USE {}'.format(self._configs.space_name))
+                    if resp.error_code != 0:
+                        raise RuntimeError(
+                            'Failed to get session, cannot set the session space to {}'.format(
+                                self._configs.space_name
+                            )
+                        )
+                    return session
+                except Exception:
+                    raise
+        else:
+            raise RuntimeError('SSL is not supported yet')
+
+    def ping(self, address):
+        """check the server is ok
+
+        :param address: the server address want to connect
+        :return: True or False
+        """
+        try:
+            conn = Connection()
+            if self._ssl_configs is None:
+                conn.open(address[0], address[1], 1000)
+            else:
+                conn.open_SSL(address[0], address[1], 1000, self._ssl_configs)
+            conn.close()
+            return True
+        except Exception as ex:
+            logger.warning(
+                'Connect {}:{} failed: {}'.format(address[0], address[1], ex)
+            )
+            return False
+
+    def close(self):
+        """log out all sessions and close all connections
+
+        :return: void
+        """
+        with self._lock:
+            for session in self._idle_sessions:
+                session.release()
+                session.connection.close()
+            for session in self._active_sessions:
+                session.release()
+                session.connection.close()
+            self._idle_sessions.clear()
+            self._close = True
+
+    def connects(self):
+        """get the number of existing connections
+
+        :return: the number of connections
+        """
+        with self._lock:
+            count = 0
+            for addr in self._sessions.keys():
+                count = count + len(self._sessions[addr])
+            return count
+
+    def get_ok_servers_num(self):
+        """get the number of the ok servers
+
+        :return: int
+        """
+        count = 0
+        for addr in self._addresses_status.keys():
+            if self._addresses_status[addr] == self.S_OK:
+                count = count + 1
+        return count
+
+    def _get_services_status(self):
+        msg_list = []
+        for addr in self._addresses_status.keys():
+            status = 'OK'
+            if self._addresses_status[addr] != self.S_OK:
+                status = 'BAD'
+            msg_list.append('[services: {}, status: {}]'.format(addr, status))
+        return ', '.join(msg_list)
+
+    def update_servers_status(self):
+        """update the servers' status"""
+        for address in self._addresses:
+            if self.ping(address):
+                self._addresses_status[address] = self.S_OK
+            else:
+                self._addresses_status[address] = self.S_BAD
+
+    def ping_sessions(self):
+        """ping all sessions in the pool"""
+        with self._lock:
+            for session in self._idle_sessions:
+                session.execute(r'RETURN "SESSION PING"')
+
+    def _remove_idle_unusable_session(self):
+        if self._configs.idle_time == 0:
+            return
+        with self._lock:
+            for addr in self._sessions.keys():
+                conns = self._sessions[addr]
+                for connection in list(conns):
+                    if not connection.is_used:
+                        if not connection.ping():
+                            logger.debug(
+                                'Remove the not unusable connection to {}'.format(
+                                    connection.get_address()
+                                )
+                            )
+                            conns.remove(connection)
+                            continue
+                        if (
+                            self._configs.idle_time != 0
+                            and connection.idle_time() > self._configs.idle_time
+                        ):
+                            logger.debug(
+                                'Remove the idle connection to {}'.format(
+                                    connection.get_address()
+                                )
+                            )
+                            conns.remove(connection)
+
+    def _period_detect(self):
+        """periodically detect the services status"""
+        if self._close or self._configs.interval_check < 0:
+            return
+        self.update_servers_status()
+        self._remove_idle_unusable_session()
+        timer = Timer(self._configs.interval_check, self._period_detect)
+        timer.setDaemon(True)
+        timer.start()
+
+    def _check_configs(self):
+        """validate the configs"""
+        if self._configs.min_size < 0:
+            raise RuntimeError('The min_size must be greater than 0')
+        if self._configs.max_size < 0:
+            raise RuntimeError('The max_size must be greater than 0')
+        if self._configs.min_size > self._configs.max_size:
+            raise RuntimeError(
+                'The min_size must be less than or equal to the max_size'
+            )
+        if self._configs.idle_time < 0:
+            raise RuntimeError('The idle_time must be greater or equal to 0')
+        if self._configs.space_name == "":
+            raise RuntimeError('The space_name must be set')
+        if self._configs.timeout < 0:
+            raise RuntimeError('The timeout must be greater or equal to 0')

--- a/tests/test_session_pool.py
+++ b/tests/test_session_pool.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+# --coding:utf-8--
+
+# Copyright (c) 2022 vesoft inc. All rights reserved.
+#
+# This source code is licensed under Apache 2.0 License.
+
+
+import sys
+import os
+import threading
+import time
+import pytest
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+root_dir = os.path.join(current_dir, '..')
+sys.path.insert(0, root_dir)
+
+from unittest import TestCase
+from nebula3.common.ttypes import ErrorCode
+from nebula3.gclient.net.SessionPool import SessionPool
+from nebula3.gclient.net import Connection
+from nebula3.Config import SessionPoolConfig
+
+from nebula3.Exception import (
+    NoValidSessionException,
+    InValidHostname,
+    IOErrorException,
+)
+
+
+class TestSessionPool(TestCase):
+    @classmethod
+    def setup_class(self):
+        self.addresses = list()
+        self.addresses.append(('127.0.0.1', 9669))
+        self.addresses.append(('127.0.0.1', 9670))
+        self.configs = SessionPoolConfig()
+        self.configs.min_size = 2
+        self.configs.max_size = 4
+        self.configs.idle_time = 2000
+        self.configs.interval_check = 2
+
+        # prepare space
+        conn = Connection()
+        conn.open('127.0.0.1', 9669, 1000)
+        auth_result = conn.authenticate('root', 'nebula')
+        assert auth_result.get_session_id() != 0
+        resp = conn.execute(
+            auth_result._session_id,
+            'CREATE SPACE IF NOT EXISTS session_pool_test(vid_type=FIXED_STRING(30))',
+        )
+        assert resp.error_code == ErrorCode.SUCCEEDED
+        # insert data need to sleep after create schema
+        time.sleep(10)
+
+        self.session_pool = SessionPool(
+            'root', 'nebula', 'session_pool_test', self.addresses
+        )
+        assert self.session_pool.init(self.configs)
+
+    def test_right_hostname(self):
+        session_pool = SessionPool(
+            'root', 'nebula', 'session_pool_test', self.addresses
+        )
+        assert session_pool.init(self.configs)
+
+    def test_wrong_hostname(self):
+        session_pool = SessionPool(
+            'root', 'nebula', 'session_pool_test', ('wrong_host', 9669)
+        )
+        try:
+            session_pool.init(self.configs)
+            assert False
+        except InValidHostname:
+            assert True
+
+    def test_ping(self):
+        assert self.pool.ping(('127.0.0.1', 9669))
+        assert self.pool.ping(('127.0.0.1', 5000)) is False
+
+    def test_init_failed(self):
+        # init succeeded
+        pool1 = SessionPool()
+        addresses = list()
+        addresses.append(('127.0.0.1', 9669))
+        addresses.append(('127.0.0.1', 9670))
+        assert pool1.init(addresses, Config())
+
+        # init failed, connected failed
+        pool2 = SessionPool()
+        addresses = list()
+        addresses.append(('127.0.0.1', 3800))
+        try:
+            pool2.init(addresses, Config())
+            assert False
+        except Exception:
+            assert True
+
+        # init failed, hostname not existed
+        try:
+            pool3 = SessionPool()
+            addresses = list()
+            addresses.append(('not_exist_hostname', 3800))
+            assert not pool3.init(addresses, Config())
+        except InValidHostname:
+            assert True, "We expected get the exception"
+
+
+def test_multi_thread():
+    # Test multi thread
+    addresses = [('127.0.0.1', 9669), ('127.0.0.1', 9670)]
+    configs = Config()
+    configs.max_connection_pool_size = 4
+    pool = SessionPool()
+    assert pool.init(addresses, configs)
+
+    global success_flag
+    success_flag = True
+
+    def main_test():
+        session = None
+        global success_flag
+        try:
+            session = pool.get_session('root', 'nebula')
+            if session is None:
+                success_flag = False
+                return
+            space_name = 'space_' + threading.current_thread().getName()
+
+            session.execute('DROP SPACE %s' % space_name)
+            resp = session.execute(
+                'CREATE SPACE IF NOT EXISTS %s(vid_type=FIXED_STRING(8))' % space_name
+            )
+            if not resp.is_succeeded():
+                raise RuntimeError('CREATE SPACE failed: {}'.format(resp.error_msg()))
+
+            time.sleep(3)
+            resp = session.execute('USE %s' % space_name)
+            if not resp.is_succeeded():
+                raise RuntimeError('USE SPACE failed:{}'.format(resp.error_msg()))
+
+        except Exception as x:
+            print(x)
+            success_flag = False
+            return
+        finally:
+            if session is not None:
+                session.release()
+
+    thread1 = threading.Thread(target=main_test, name='thread1')
+    thread2 = threading.Thread(target=main_test, name='thread2')
+    thread3 = threading.Thread(target=main_test, name='thread3')
+    thread4 = threading.Thread(target=main_test, name='thread4')
+
+    thread1.start()
+    thread2.start()
+    thread3.start()
+    thread4.start()
+
+    thread1.join()
+    thread2.join()
+    thread3.join()
+    thread4.join()
+
+    pool.close()
+    assert success_flag


### PR DESCRIPTION
## Why we need a session pool
The purpose of adding the  `session pool` is to solve the problem caused by improperly using the connection pool. For example, a common case is that the user generates a new session, executes a query, and releases the session in a loop, like:
```
// Wrong usage of the connection pool
for(int i=0; i<100; i++) {
  // get new session
  // execute query
  // release session
}
```
This will cause huge traffic in the meta service and may crash the service.

## Usage
See `example/SessinPoolExample.py` for a more detailed example.

The usage of the connection pool remains unchanged.

## Limitation
There are some limitations:
1. There **MUST** be an existing `space` in the DB before initializing the session pool.
2. Each session pool is corresponding to a single **USER** and a single **Space**. This is to ensure that the user's access control is consistent. i.g. The same user may have different access privileges in different spaces. If you need to run queries in different spaces, you may have multiple session pools.
3. Every time when `sessinPool.execute()` is called, the session will execute the query in the space set in the session pool config.
4. Commands that alter passwords or drop users should **NOT** be executed via session pool.
