### PR TITLE
fix: ValueWrapper.cast support __EMPTY__ type

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ def result_to_df(result: ResultSet) -> pd.DataFrame:
         col_name = columns[col_num]
         col_list = result.column_values(col_name)
         d[col_name] = [x.cast() for x in col_list]
-    return pd.DataFrame.from_dict(d, columns=columns)
+    return pd.DataFrame.from_dict(d, orient='columns')
 
 # define a config
 config = Config()

--- a/nebula3/data/DataObject.py
+++ b/nebula3/data/DataObject.py
@@ -26,7 +26,6 @@ from nebula3.common.ttypes import (
 
 __AS_MAP__ = {
     Value.NVAL: "as_null",
-    Value.__EMPTY__: "as_empty",
     Value.BVAL: "as_bool",
     Value.IVAL: "as_int",
     Value.FVAL: "as_double",
@@ -686,6 +685,8 @@ class ValueWrapper(object):
         : return: Any type (e.g. int, float, List[Dict[str, int]], Set[List[float]])
         """
         _type = self._value.getType()
+        if _type == Value.__EMPTY__:
+            return None
         if _type in __AS_MAP__:
             # Considering the most efficient way, we should call `cast` in every iterable method over their items,
             # such as `as_list`, `as_set`, and `as_map`. However, the returned type will change and cause incompatibility.


### PR DESCRIPTION
it now calls as_empty which doesn't exist.

<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
n/a

#### Description:
Previously it could not handle empty properly.

## How do you solve it?
- Removed the as_empty call from the attribute map
- return None when it's empty

