### PR TITLE
fix(SessinPoolExample.py): change port

### DIFF
--- a/example/SessinPoolExample.py
+++ b/example/SessinPoolExample.py
@@ -17,7 +17,7 @@ from FormatResp import print_resp
 
 if __name__ == '__main__':
     ip = '127.0.0.1'
-    port = 3699
+    port = 9669
 
     try:
         config = SessionPoolConfig()


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

None

Current code will cause this error:

```
PS D:\Git\Playground\nebula-python\example> py SessinPoolExample.py
Traceback (most recent call last):
  File "C:\Environment\Python\Python311\Lib\site-packages\nebula3\fbthrift\transport\TSocket.py", line 286, in open
    handle.connect(address)
TimeoutError: timed out

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "D:\Git\Playground\nebula-python\example\SessinPoolExample.py", line 27, in <module>
    conn.open(ip, port, 1000)
  File "C:\Environment\Python\Python311\Lib\site-packages\nebula3\gclient\net\Connection.py", line 52, in open
    self.open_SSL(ip, port, timeout, None)
  File "C:\Environment\Python\Python311\Lib\site-packages\nebula3\gclient\net\Connection.py", line 89, in open_SSL
    header_transport.open()
  File "C:\Environment\Python\Python311\Lib\site-packages\nebula3\fbthrift\transport\THeaderTransport.py", line 247, in open
    return self.getTransport().open()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Environment\Python\Python311\Lib\site-packages\nebula3\fbthrift\transport\TTransport.py", line 173, in open
    return self.__trans.open()
           ^^^^^^^^^^^^^^^^^^^
  File "C:\Environment\Python\Python311\Lib\site-packages\nebula3\fbthrift\transport\TSocket.py", line 301, in open
    raise TTransportException(TTransportException.NOT_OPEN, msg)
nebula3.fbthrift.transport.TTransport.TTransportException: socket error connecting to host 127.0.0.1, port 3699 (('127.0.0.1', 3699)): TimeoutError('timed out')
```

#### Description:

Nebula's default port had been changed to [9669](https://github.com/vesoft-inc/nebula-docker-compose/blob/0d47bbd5300758f80b60b805c035ad04e27cab34/docker-compose.yaml#L219-L226) since [2.0.1-RC](https://docs.nebula-graph.com.cn/2.0.1/2.quick-start/2.deploy-nebula-graph-with-docker-compose/#nebula-docker-composenebula_graph_200-rc3699nebula_graph). [Latest version](https://docs.nebula-graph.com.cn/master/2.quick-start/3.quick-start-on-premise/3.connect-to-nebula-graph/#_2) still using 9669 port.


## How do you solve it?

Change port variable's value


