### PR TITLE
fix leader change

### DIFF
--- a/nebula3/sclient/__init__.py
+++ b/nebula3/sclient/__init__.py
@@ -173,7 +173,7 @@ def do_scan_job(
                         )
                         storage_connection.update_leader_info(
                             req.space_id,
-                            req.part_id,
+                            resp.result.failed_parts[0].part_id,
                             resp.result.failed_parts[0].leader,
                         )
                         continue


### PR DESCRIPTION
fix scan if leader change.

original error:

```
part_id 9 has leader change, old leader is HostAddr(
    host='192.168.15.7',
    port=9779), new leader is HostAddr(
    host='192.168.15.6',
    port=9779)
Traceback (most recent call last):
  File "/home/jingchun.xia/anaconda3/lib/python3.11/site-packages/nebula3/sclient/__init__.py", line 176, in do_scan_job
    req.part_id,
    ^^^^^^^^
AttributeError: 'ScanEdgeRequest' object has no attribute 'part_id'
```