### PR TITLE
feat: support JupyterLite/Emscripten

### DIFF
--- a/nebula3/fbthrift/transport/TSocket.py
+++ b/nebula3/fbthrift/transport/TSocket.py
@@ -201,6 +201,11 @@ class TSocketBase(TTransportBase):
         if fcntl is None:
             return
 
+        # pyodide doesn't support fcntl, so we need to skip in this case, too.
+        # ref: https://github.com/pyodide/pyodide/discussions/4150
+        if sys.platform == 'emscripten':
+            return
+
         flags = fcntl.fcntl(handle, fcntl.F_GETFD, 0)
         if flags < 0:
             raise IOError('Error in retrieving file options')


### PR DESCRIPTION
## What type of PR is this?
- [ ] bug
- [x] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

- https://github.com/wey-gu/jupyter_nebulagraph/issues/46
- https://github.com/pyodide/pyodide/discussions/4150
- https://github.com/emscripten-core/emscripten/issues/11797

#### Description:

This is a fix on Thrift python, to enable nebula-python being supported on jupyterlite, a wasm env in browser powered by pyodide.

This will enable embedding runnable jupyter/python client runtime of nebulagraph in a browser or inline of docs/tutorials in the future.


## How do you solve it?

This is an equivalent downstream implementation of my [pr on fbthrift](https://github.com/facebook/fbthrift/pull/597). 

Just to inspect the sys platform and when it's on WASM(with Emscripten), just don't lock as it was done for Windows.

## Note

This change has to be applied again every time thrift gen was triggered.
