### PR TITLE
fix: support conn_pool ping before init | add missing dep in py3.6

### DIFF
--- a/nebula3/gclient/net/ConnectionPool.py
+++ b/nebula3/gclient/net/ConnectionPool.py
@@ -220,6 +220,9 @@ class ConnectionPool(object):
         """
         try:
             conn = Connection()
+            # support ping before self.init()
+            if self._configs is None:
+                self._configs = Config()
             conn.open_SSL(
                 address[0],
                 address[1],

--- a/nebula3/gclient/net/SessionPool.py
+++ b/nebula3/gclient/net/SessionPool.py
@@ -86,6 +86,8 @@ class SessionPool(object):
                 configs, SessionPoolConfig
             ), 'wrong type of SessionPoolConfig, try this: `from nebula3.Config import SessionPoolConfig`'
             self._configs = configs
+        else:
+            self._configs = SessionPoolConfig()
         # check configs
         try:
             self._check_configs()

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         'six >= 1.16.0',
         'pytz >= 2021.1',
         'httpx[http2] >= 0.22.0',
+        'contextvars==2.4', # for python 3.6
     ],
     packages=find_packages(),
     platforms=['3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12'],

--- a/setup.py
+++ b/setup.py
@@ -4,33 +4,38 @@
 #
 # This source code is licensed under Apache 2.0 License.
 
-
+import sys
 from setuptools import setup, find_packages
 from pathlib import Path
 
 base_dir = Path(__file__).parent
-long_description = (base_dir / 'README.md').read_text()
+long_description = (base_dir / "README.md").read_text()
 
+requirements = [
+    "httplib2 >= 0.20.0",
+    "future >= 0.18.0",
+    "six >= 1.16.0",
+    "pytz >= 2021.1",
+    "httpx[http2] >= 0.22.0",
+]
+
+if sys.version_info < (3, 7):
+    # httpcore-->anyio-->contextvars when it's < 3.7
+    # while setuptools doesn't handle the dependency well
+    requirements.append("contextvars==2.4")
 
 setup(
-    name='nebula3-python',
-    version='3.8.0',
-    license='Apache 2.0',
-    author='vesoft-inc',
-    author_email='info@vesoft.com',
-    description='Python client for NebulaGraph V3.4',
+    name="nebula3-python",
+    version="3.8.0",
+    license="Apache 2.0",
+    author="vesoft-inc",
+    author_email="info@vesoft.com",
+    description="Python client for NebulaGraph V3.4",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    url='https://github.com/vesoft-inc/nebula-python',
-    install_requires=[
-        'httplib2 >= 0.20.0',
-        'future >= 0.18.0',
-        'six >= 1.16.0',
-        'pytz >= 2021.1',
-        'httpx[http2] >= 0.22.0',
-        'contextvars==2.4', # for python 3.6
-    ],
+    long_description_content_type="text/markdown",
+    url="https://github.com/vesoft-inc/nebula-python",
+    install_requires=requirements,
     packages=find_packages(),
-    platforms=['3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12'],
-    package_dir={'nebula3': 'nebula3'},
+    platforms=["3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12"],
+    package_dir={"nebula3": "nebula3"},
 )


### PR DESCRIPTION
In NebulaGraph repo ci test, ping was done before the connection pool's init, this was broken in recent changes.
This change fixed it.

issue 1:

a. connection_pool cannot be ping() without init()

b. dependency issue:
- http2 was added, it relied on httpcore-->anyio-->contextvars(only needed when python < 3.7)
- in setup.py, there were httpx[http2] >= 0.22.0, ensures `httpcore-->anyio` BUT NOT `contextvars`

WHY this issue(a, or b) was not found? It could be due to a dirty cache, see issue 2 hided issue 1.

Action: added this dep handling in setup.py

issue 2:

dirty cache in gh runner in `/home/vesoft/actions-runner/_work/_temp/_github_home/.local`

```bash

docker run --rm -e "HOME=/github/home" -v "/home/vesoft/actions-runner/_work/_temp/_github_home":"/github/home" -it vesoft/nebula-dev:centos7

bash-4.2# pip3 freeze | grep nebula
nebula3-python==3.5.1

>>> sys.path
['', '/usr/lib64/python36.zip', '/usr/lib64/python3.6', '/usr/lib64/python3.6/lib-dynload', '/github/home/.local/lib/python3.6/site-packages', '/usr/local/lib/python3.6/site-packages', '/usr/lib64/python3.6/site-packages', '/usr/lib/python3.6/site-packages']
>>> import nebula3
>>> nebula3.__file__
'/github/home/.local/lib/python3.6/site-packages/nebula3/__init__.py'

```

WHY `.local` exist unexpected nebula3-python package? It could be caused by attempts of pip3 install --user:

```
bash-4.2# pip3 install --user nebula2-python
WARNING: Running pip install with root privileges is generally not a good idea. Try `pip3 install --user` instead.
Collecting nebula2-python
  Downloading https://files.pythonhosted.org/packages/49/a8/75bf56857e3d42f33d569b449be3435f82b783a4d57fcaab34349cc029bd/nebula2_python-2.6.1-py3-none-any.whl (301kB)
    100% |████████████████████████████████| 307kB 1.2MB/s
Requirement already satisfied: pytz in /github/home/.local/lib/python3.6/site-packages (from nebula2-python)
Requirement already satisfied: six in /github/home/.local/lib/python3.6/site-packages (from nebula2-python)
Requirement already satisfied: future in /github/home/.local/lib/python3.6/site-packages (from nebula2-python)
Requirement already satisfied: httplib2 in /github/home/.local/lib/python3.6/site-packages (from nebula2-python)
Requirement already satisfied: pyparsing!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3,<4,>=2.4.2; python_version > "3.0" in /github/home/.local/lib/python3.6/site-packages (from httplib2->nebula2-python)
Installing collected packages: nebula2-python
Successfully installed nebula2-python-2.6.1

bash-4.2# pip3 uninstall nebula2-python -y
Uninstalling nebula2-python-2.6.1:
  Successfully uninstalled nebula2-python-2.6.1
```

And in `vesoft-inc/nebua`, it's doing so(install 3.5.1 with `pip3 install --user`

```makefile
install-nebula-py: install-deps
	git clone --branch release-3.5 https://github.com/vesoft-inc/nebula-python $(CURR_DIR)/nebula-python
	cd $(CURR_DIR)/nebula-python \
		&& pip3 install --user . -i $(PYPI_MIRROR) --upgrade
	rm -rf $(CURR_DIR)/nebula-python
```

Action: force to remove unexpected nebula3-python packages before installation first, we need to ensure .local is cleaned in runner cache.