### PR TITLE
Update ResultSet.py

### DIFF
--- a/nebula3/data/ResultSet.py
+++ b/nebula3/data/ResultSet.py
@@ -312,7 +312,9 @@ class ResultSet(object):
                         "props": props,
                     }
                 else:
-                    edges_dict[str((src_id, dst_id, rank, edge_name))]["props"].update(props)
+                    edges_dict[str((src_id, dst_id, rank, edge_name))]["props"].update(
+                        props
+                    )
 
             elif isinstance(item, PathWrapper):
                 for node in item.nodes():

--- a/nebula3/data/ResultSet.py
+++ b/nebula3/data/ResultSet.py
@@ -312,7 +312,7 @@ class ResultSet(object):
                         "props": props,
                     }
                 else:
-                    edges_dict[(src_id, dst_id, rank, edge_name)]["props"].update(props)
+                    edges_dict[str((src_id, dst_id, rank, edge_name))]["props"].update(props)
 
             elif isinstance(item, PathWrapper):
                 for node in item.nodes():


### PR DESCRIPTION
Fixes a bug where the tuple (src_id, dst_id, rank, edge_name) is used as the a key when accessing edges_dict, instead of the string representation of the tuple.

<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 


#### Description:


## How do you solve it?


## Special notes for your reviewer, ex. impact of this fix, design document, etc:


