### PR TITLE
fix connection not release bug

### DIFF
--- a/nebula3/gclient/net/Connection.py
+++ b/nebula3/gclient/net/Connection.py
@@ -172,7 +172,6 @@ class Connection(object):
             resp = self._connection.authenticate(user_name, password)
             if resp.error_code != ErrorCode.SUCCEEDED:
                 self._connection.is_used = False
-                self._connection = None
                 raise AuthFailedException(resp.error_msg)
             return AuthResult(
                 resp.session_id, resp.time_zone_offset_seconds, resp.time_zone_name

--- a/nebula3/gclient/net/Connection.py
+++ b/nebula3/gclient/net/Connection.py
@@ -171,6 +171,8 @@ class Connection(object):
         try:
             resp = self._connection.authenticate(user_name, password)
             if resp.error_code != ErrorCode.SUCCEEDED:
+                self._connection.is_used = False
+                self._connection = None
                 raise AuthFailedException(resp.error_msg)
             return AuthResult(
                 resp.session_id, resp.time_zone_offset_seconds, resp.time_zone_name


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 


#### Description:
When authenticate to graphd failed,the status of the connection has not been modified, resulting in the inability to continue using it in the future.I encountered this issue and thinking this commit can fix it.

## How do you solve it?
Modify connection status `is_used` to False

## Special notes for your reviewer, ex. impact of this fix, design document, etc:


