### PR TITLE
chore: fix session pool del before lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ See [ScanVertexEdgeExample.py](example/ScanVertexEdgeExample.py) for more detail
 
 | Nebula-Python Version | Compatible NebulaGraph Versions | Notes                                                      |
 | --------------------- | ------------------------------- | ---------------------------------------------------------- |
-| 3.8.2                 | 3.x                             | Highly recommended. Latest release for NebulaGraph 3.x series. |
+| 3.8.3                 | 3.x                             | Highly recommended. Latest release for NebulaGraph 3.x series. |
 | master                | master                          | Includes recent changes. Not yet released.                 |
 | 3.0.0 ~ 3.5.1         | 3.x                             | Compatible with any released version within the NebulaGraph 3.x series. |
 | 2.6.0                 | 2.6.0, 2.6.1                    |                                                            |

--- a/nebula3/gclient/net/SessionPool.py
+++ b/nebula3/gclient/net/SessionPool.py
@@ -70,7 +70,8 @@ class SessionPool(BaseExecutor, object):
         self._close = False
 
     def __del__(self):
-        self.close()
+        if hasattr(self, '_lock'):
+            self.close()
 
     def init(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nebula3-python"
-version = "3.8.2"
+version = "3.8.3"
 description = "Python client for NebulaGraph v3"
 authors = [
     {name = "vesoft-inc", email = "info@vesoft.com"},

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ if sys.version_info < (3, 7):
 
 setup(
     name="nebula3-python",
-    version="3.8.2",
+    version="3.8.3",
     license="Apache 2.0",
     author="vesoft-inc",
     author_email="info@vesoft.com",


### PR DESCRIPTION
tests/test_session_pool.py::test_session_pool_multi_thread

tests/test_session_pool.py::TestSessionPoolBasic::test_pool_init
  /home/runner/work/nebula-python/nebula-python/.venv/lib/python3.12/site-packages/_pytest/unraisableexception.py:78: PytestUnraisableExceptionWarning: Exception ignored in: <function SessionPool.__del__ at 0x7f7fff215760>

  Traceback (most recent call last):
    File "/home/runner/work/nebula-python/nebula-python/nebula3/gclient/net/SessionPool.py", line 73, in __del__
      self.close()
    File "/home/runner/work/nebula-python/nebula-python/nebula3/gclient/net/SessionPool.py", line 329, in close
      with self._lock:
           ^^^^^^^^^^
  AttributeError: 'SessionPool' object has no attribute '_lock'



