### PR TITLE
fix: session leak on re-auth and init failure

### DIFF
--- a/src/nebulagraph_python/client/_connection.py
+++ b/src/nebulagraph_python/client/_connection.py
@@ -494,7 +494,7 @@ class AsyncConnection:
                 request, timeout=self.config.request_timeout
             )
         except grpc.aio.AioRpcError as e:
-            self.close()
+            await self.close()
             logger.error(
                 f"Async RPC error during authenticate: {e.code()} {e.details()}"
             )
@@ -502,14 +502,14 @@ class AsyncConnection:
                 f"RPC error during authentication: {e.details()}"
             ) from e
         except Exception as e:  # Catch other potential errors
-            self.close()
+            await self.close()
             logger.error(f"Unexpected error during async authenticate: {e}")
             raise AuthenticatingError(
                 "Unexpected error during async authentication"
             ) from e
 
         if response.status.code != b"00000":
-            self.close()
+            await self.close()
             raise NebulaGraphRemoteError(
                 code=ErrorCode(response.status.code.decode("utf-8")),
                 message=response.status.message.decode("utf-8"),


### PR DESCRIPTION
needs await self.close() to close the underlying channel?

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 


#### Description:


## How do you solve it?

await

## Special notes for your reviewer, ex. impact of this fix, design document, etc:


